### PR TITLE
fix(keeper): rm validator reg; monitoring; invert removal order

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,8 +10,8 @@
 .idea
 .vscode
 *.md
-node_modules
-dist
+**/node_modules
+**/dist
 packages/mcp/
 off-chain-actions.md
 claude-code-*

--- a/packages/keeper/README.md
+++ b/packages/keeper/README.md
@@ -1,11 +1,11 @@
 # suzaku-keeper
 
-Keeper bot for Suzaku StakingVault contracts. Runs permissionless maintenance operations - epoch processing, withdrawal preparation, harvest, and validator/delegator lifecycle completions - that keep a vault healthy and its withdrawal queue moving.
+Keeper bot for Suzaku StakingVault contracts. Runs permissionless maintenance operations - epoch processing, withdrawal preparation, harvest, and delegator lifecycle completions - that keep a vault healthy and its withdrawal queue moving.
 
 The keeper has two categories of work:
 
 - **Core operations** (L1 key only) - epoch processing, withdrawal preparation, harvest, queue cleanup. These are pure L1 transactions.
-- **P-Chain operations** (L1 key + P-Chain key) - completing two-phase validator/delegator registrations and removals. These require signing P-Chain transactions via warp messages.
+- **P-Chain operations** (L1 key + P-Chain key) - completing two-phase delegator registrations and removals. These require signing P-Chain transactions via warp messages.
 
 ## Requirements
 
@@ -35,6 +35,9 @@ echo "VAULT_ADDRESS=0x..." >> .env
 mkdir -p secrets
 echo -n "0x..." > secrets/pk.txt
 echo -n "0x..." > secrets/pchain_tx_private_key.txt
+# pk_completions.txt is the L1 key used by the completions container.
+# If you don't need a separate key, reuse pk.txt:
+[ -f secrets/pk_completions.txt ] || cp secrets/pk.txt secrets/pk_completions.txt
 
 # Start both containers (core + completions)
 docker compose up -d
@@ -72,14 +75,16 @@ When pending withdrawals exist, calls `prepareWithdrawals()` to earmark liquid b
 
 ### P-Chain completions (registrations + removals)
 
-Validator and delegator lifecycle operations are two-phase: first you *initiate* on the L1 (C-Chain tx), then you *complete* on the P-Chain (warp message + P-Chain tx). The keeper automates the second step.
+Delegator lifecycle operations are two-phase: first you *initiate* on the L1 (C-Chain tx), then you *complete* on the P-Chain (warp message + P-Chain tx). The keeper automates the second step.
 
-It scans all operators' validators and delegators for pending operations:
+It scans all operators' delegators for pending operations:
 
-- **Registration completions** - finds validators/delegators in `PendingAdded` status, locates the initiation tx via event logs, and calls `completeValidatorRegistration` / `completeDelegatorRegistration`.
+- **Delegator registration completions** - finds delegators in `PendingAdded` status, locates the initiation tx via event logs, and calls `completeDelegatorRegistration`. Requires `--uptime-rpc-url` to fetch uptime proofs.
 - **Removal completions** - finds validators/delegators with pending removals and calls `completeValidatorRemoval` / `completeDelegatorRemoval`.
 
-Requires `PCHAIN_TX_PRIVATE_KEY`. If omitted, the keeper skips these entirely.
+> **Note:** Validator registration completions are **not** automated by the keeper. They must be triggered manually via the CLI.
+
+Requires `PCHAIN_TX_PRIVATE_KEY` and `UPTIME_RPC_URL`. If omitted, the keeper skips these entirely.
 
 ### Harvest
 
@@ -106,6 +111,7 @@ VAULT_ADDRESS=0x...
 RPC_URL=http://host:port/ext/bc/<blockchainID>/rpc
 VAULT_ADDRESS=0x...
 SKIP_ABI_VALIDATION=true
+UPTIME_RPC_URL=http://host:port/ext/bc/<uptimeBlockchainID>/rpc  # required for completions
 # UPTIME_BLOCKCHAIN_ID=0x...    # optional: auto-read from staking manager storage
 
 # Private keys go in secrets/ (mounted as Docker secrets, not env vars)
@@ -113,7 +119,7 @@ SKIP_ABI_VALIDATION=true
 # names will be treated as GPG keystore references and fail in Docker.
 # secrets/pk.txt                - L1 private key (required)
 # secrets/pchain_tx_private_key.txt - P-Chain key (required for completions)
-# secrets/pk_completions.txt    - optional: separate L1 key for completions container
+# secrets/pk_completions.txt    - L1 key for completions container (required; copy pk.txt if no separate key)
 
 docker compose up -d
 ```
@@ -124,22 +130,22 @@ docker compose up -d
 
 ```bash
 # Single run - everything (core + P-Chain operations)
-node dist/index.js run 0x1234...abcd -n kiteaitestnet --harvest --pchain-tx-private-key 0x...
+node dist/index.js run 0x1234...abcd -n kiteaitestnet --harvest --pchain-tx-private-key 0x... --uptime-rpc-url http://host:port/...
 
 # Single run - core operations only (no P-Chain key needed)
 node dist/index.js run 0x1234...abcd -n kiteaitestnet --harvest --core
 
-# Single run - P-Chain operations only (registration/removal completions)
-node dist/index.js run 0x1234...abcd -n kiteaitestnet --completions --pchain-tx-private-key 0x...
+# Single run - P-Chain operations only (delegator registration/removal completions)
+node dist/index.js run 0x1234...abcd -n kiteaitestnet --completions --pchain-tx-private-key 0x... --uptime-rpc-url http://host:port/...
 
 # Daemon - everything
-node dist/index.js watch 0x1234...abcd -n kiteaitestnet --pchain-tx-private-key 0x...
+node dist/index.js watch 0x1234...abcd -n kiteaitestnet --pchain-tx-private-key 0x... --uptime-rpc-url http://host:port/...
 
 # Daemon - core operations only
 node dist/index.js watch 0x1234...abcd -n kiteaitestnet --core
 
 # Daemon - P-Chain operations only
-node dist/index.js watch 0x1234...abcd -n kiteaitestnet --completions --pchain-tx-private-key 0x...
+node dist/index.js watch 0x1234...abcd -n kiteaitestnet --completions --pchain-tx-private-key 0x... --uptime-rpc-url http://host:port/...
 ```
 
 ## Monitoring & Observability
@@ -184,16 +190,16 @@ Every tick writes a JSON line to stderr:
 
 ### Grafana Dashboard
 
-A pre-built dashboard JSON is included at `grafana-dashboard.json`. To use it, start the monitoring stack and import it manually into Grafana:
+Start the monitoring stack and the Suzaku Keeper dashboard loads automatically — no manual import needed:
 
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up -d
 ```
 
 - **Prometheus** - `http://localhost:9092`
-- **Grafana** - `http://localhost:3000` (no login, anonymous viewer)
+- **Grafana** - `http://localhost:3000` (anonymous viewer, no login required)
 
-Import `grafana-dashboard.json` via the Grafana UI (Dashboards → Import). The dashboard includes: TVL, solvency ratio, exchange rate, vault paused status, epoch lag, queue depth, available stake vs pending withdrawals, protocol fees, per-operator stake/debt/validators/delegators, keeper tick duration, error rate, and event rates.
+The dashboard is provisioned automatically from `grafana-dashboard.json` and includes: TVL, solvency ratio, exchange rate, vault paused status, epoch lag, queue depth, available stake vs pending withdrawals, protocol fees, per-operator stake/debt/validators/delegators, keeper tick duration, error rate, and event rates.
 
 ## Commands Reference
 
@@ -225,6 +231,7 @@ Single keeper pass. Runs the selected operations once and exits.
 | `--pchain-tx-private-key <pk>` | - | `PCHAIN_TX_PRIVATE_KEY` | P-Chain key for completing registrations/removals |
 | `--core` | off | - | Core operations only |
 | `--completions` | off | - | P-Chain completions only |
+| `--uptime-rpc-url <url>` | - | `UPTIME_RPC_URL` | RPC URL for the uptime-tracking chain. **Required when completions are enabled** |
 | `--uptime-blockchain-id <hex>` | auto | `UPTIME_BLOCKCHAIN_ID` | Blockchain ID for uptime proofs |
 
 ### `watch <stakingVaultAddress>`
@@ -239,6 +246,7 @@ Long-running daemon. Runs keeper passes on a polling interval with a separate ha
 | `--pchain-tx-private-key <pk>` | - | `PCHAIN_TX_PRIVATE_KEY` | P-Chain key for completing registrations/removals |
 | `--core` | off | - | Core operations only |
 | `--completions` | off | - | P-Chain completions only |
+| `--uptime-rpc-url <url>` | - | `UPTIME_RPC_URL` | RPC URL for the uptime-tracking chain. **Required when completions are enabled** |
 | `--uptime-blockchain-id <hex>` | auto | `UPTIME_BLOCKCHAIN_ID` | Blockchain ID for uptime proofs |
 
 ## Environment Variables
@@ -250,6 +258,7 @@ Long-running daemon. Runs keeper passes on a polling interval with a separate ha
 | `RPC_URL` | no | RPC URL for the L1 where the StakingVault lives. Auto-detects chain ID and sets `--network custom`. Required for custom L1s not in the built-in chain list |
 | `VAULT_ADDRESS` | yes | StakingVault contract address (used by docker-compose to pass the CLI argument) |
 | `PCHAIN_TX_PRIVATE_KEY` | no | P-Chain private key (`0x`-prefixed hex) for two-phase completions. If omitted, the keeper skips completions. In Docker, provided via file-based secret (`secrets/pchain_tx_private_key.txt`) |
+| `UPTIME_RPC_URL` | **yes (if completions)** | RPC URL for the uptime-tracking chain (the chain that tracks validator uptime for delegator registration completions). Required when `PCHAIN_TX_PRIVATE_KEY` is set or `--completions` is used |
 | `UPTIME_BLOCKCHAIN_ID` | no | Blockchain ID (hex) for uptime proofs. Auto-read from staking manager storage if omitted |
 | `SKIP_ABI_VALIDATION` | no | Set to any non-empty value to skip contract ABI validation. Required for custom L1s where the ABI selectors may not match the on-chain bytecode |
 | `METRICS_PORT` | no | Prometheus metrics port (default: `9090`, set `0` to disable) |
@@ -279,7 +288,7 @@ If you don't need P-Chain completions, start only the core container:
 docker compose up -d keeper-core
 ```
 
-This avoids needing `secrets/pchain_tx_private_key.txt` and `secrets/pk_completions.txt`.
+This avoids needing `secrets/pchain_tx_private_key.txt` and `secrets/pk_completions.txt` (the completions container won't start).
 
 ## Build
 

--- a/packages/keeper/README.md
+++ b/packages/keeper/README.md
@@ -1,6 +1,6 @@
 # suzaku-keeper
 
-Keeper bot for Suzaku StakingVault contracts. Runs permissionless maintenance operations - epoch processing, withdrawal preparation, harvest, and delegator lifecycle completions - that keep a vault healthy and its withdrawal queue moving.
+Keeper bot for Suzaku StakingVault contracts. Runs permissionless maintenance operations - epoch processing, withdrawal preparation, harvest, and validator/delegator lifecycle completions - that keep a vault healthy and its withdrawal queue moving.
 
 The keeper has two categories of work:
 

--- a/packages/keeper/README.md
+++ b/packages/keeper/README.md
@@ -111,7 +111,7 @@ VAULT_ADDRESS=0x...
 RPC_URL=http://host:port/ext/bc/<blockchainID>/rpc
 VAULT_ADDRESS=0x...
 SKIP_ABI_VALIDATION=true
-UPTIME_RPC_URL=http://host:port/ext/bc/<uptimeBlockchainID>/rpc  # required for completions
+UPTIME_RPC_URL=http://host:port/ext/bc/<uptimeBlockchainID>  # required for completions
 # UPTIME_BLOCKCHAIN_ID=0x...    # optional: auto-read from staking manager storage
 
 # Private keys go in secrets/ (mounted as Docker secrets, not env vars)

--- a/packages/keeper/docker-compose.monitoring.yml
+++ b/packages/keeper/docker-compose.monitoring.yml
@@ -26,6 +26,7 @@ services:
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
     volumes:
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana-dashboard.json:/var/lib/grafana/dashboards/suzaku-keeper.json:ro
     restart: unless-stopped
     networks:
       - keeper-net

--- a/packages/keeper/docker-compose.yml
+++ b/packages/keeper/docker-compose.yml
@@ -50,6 +50,7 @@ services:
     environment:
       - NETWORK=${NETWORK:-fuji}
       - RPC_URL=${RPC_URL:-}
+      - UPTIME_RPC_URL=${UPTIME_RPC_URL:-}
       - UPTIME_BLOCKCHAIN_ID=${UPTIME_BLOCKCHAIN_ID:-}
       - SKIP_ABI_VALIDATION=${SKIP_ABI_VALIDATION:-}
       - METRICS_PORT=9090

--- a/packages/keeper/grafana-dashboard.json
+++ b/packages/keeper/grafana-dashboard.json
@@ -1,144 +1,141 @@
 {
-  "dashboard": {
-    "title": "Suzaku Keeper",
-    "uid": "suzaku-keeper",
-    "panels": [
-      {
-        "id": 1,
-        "title": "TVL",
-        "description": "Total value locked — getTotalPooledStake(). Sum of all staked assets including those delegated to validators.",
-        "type": "stat",
-        "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
-        "targets": [{ "expr": "suzaku_tvl", "legendFormat": "TVL" }],
-        "fieldConfig": { "defaults": { "unit": "none", "decimals": 2 } }
-      },
-      {
-        "id": 2,
-        "title": "Solvency Ratio",
-        "description": "getTotalPooledStake() / totalSupply(). Should be ~1.0. Above 1 = undistributed rewards. Below 1 = undercollateralized. At 0, deposits are blocked (insolvency gate).",
-        "type": "gauge",
-        "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
-        "targets": [{ "expr": "suzaku_solvency_ratio" }],
-        "fieldConfig": { "defaults": { "min": 0.95, "max": 1.05, "thresholds": { "steps": [{ "value": 0, "color": "red" }, { "value": 0.99, "color": "yellow" }, { "value": 1.0, "color": "green" }] } } }
-      },
-      {
-        "id": 3,
-        "title": "Exchange Rate",
-        "description": "Share-to-asset conversion rate. Starts at 1.0 and grows as rewards accrue. A sudden drop indicates a loss event.",
-        "type": "stat",
-        "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
-        "targets": [{ "expr": "suzaku_exchange_rate" }],
-        "fieldConfig": { "defaults": { "decimals": 6 } }
-      },
-      {
-        "id": 4,
-        "title": "Vault Status",
-        "description": "0 = Active, 1 = Paused. When paused, deposits and withdrawal requests are blocked. Emergency state set by the vault admin.",
-        "type": "stat",
-        "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
-        "targets": [{ "expr": "suzaku_vault_paused" }],
-        "fieldConfig": { "defaults": { "mappings": [{ "type": "value", "options": { "0": { "text": "Active", "color": "green" }, "1": { "text": "PAUSED", "color": "red" } } }] } }
-      },
-      {
-        "id": 5,
-        "title": "Epoch Lag",
-        "description": "How many epochs behind the vault is (currentEpoch - lastEpochProcessed). The keeper calls processEpoch() to advance this. Each call processes up to 350 withdrawal entries, so large backlogs take multiple iterations. While epochs are behind, new withdrawal requests cannot be fulfilled.",
-        "type": "timeseries",
-        "gridPos": { "h": 6, "w": 12, "x": 0, "y": 4 },
-        "targets": [{ "expr": "suzaku_epoch_lag", "legendFormat": "Epochs behind" }]
-      },
-      {
-        "id": 6,
-        "title": "Queue Depth",
-        "description": "Number of withdrawal requests waiting in the FIFO queue. The queue is head-of-line blocking — one large unfulfillable request blocks everything behind it. The keeper cleans up claimable entries at the head.",
-        "type": "timeseries",
-        "gridPos": { "h": 6, "w": 12, "x": 12, "y": 4 },
-        "targets": [{ "expr": "suzaku_queue_depth", "legendFormat": "Queue depth" }]
-      },
-      {
-        "id": 7,
-        "title": "Liquidity",
-        "description": "Available Stake = liquid native token in the vault buffer, immediately available for withdrawals without unstaking. Pending Withdrawals = total native token requested but not yet claimable. When available stake drops low, prepareWithdrawals must initiate validator/delegator removals, adding 14+ day delays.",
-        "type": "timeseries",
-        "gridPos": { "h": 6, "w": 12, "x": 0, "y": 10 },
-        "targets": [
-          { "expr": "suzaku_available_stake", "legendFormat": "Available stake" },
-          { "expr": "suzaku_pending_withdrawals", "legendFormat": "Pending withdrawals" }
-        ]
-      },
-      {
-        "id": 8,
-        "title": "Pending Protocol Fees",
-        "description": "Unclaimed protocol fees in native token. Requires VAULT_ADMIN_ROLE to claim — the keeper just tracks them.",
-        "type": "timeseries",
-        "gridPos": { "h": 6, "w": 12, "x": 12, "y": 10 },
-        "targets": [{ "expr": "suzaku_pending_protocol_fees", "legendFormat": "Protocol fees" }]
-      },
-      {
-        "id": 9,
-        "title": "Operator Active Stake",
-        "description": "native token actively staked through each operator's validators and delegators.",
-        "type": "timeseries",
-        "gridPos": { "h": 6, "w": 12, "x": 0, "y": 16 },
-        "targets": [{ "expr": "suzaku_operator_active_stake", "legendFormat": "{{operator}}" }]
-      },
-      {
-        "id": 10,
-        "title": "Operator Exit Debt",
-        "description": "native token owed by each operator due to slashing or early exits. At 50% of the operator's allocation, the operator is frozen on-chain.",
-        "type": "timeseries",
-        "gridPos": { "h": 6, "w": 12, "x": 12, "y": 16 },
-        "targets": [{ "expr": "suzaku_operator_exit_debt", "legendFormat": "{{operator}}" }]
-      },
-      {
-        "id": 11,
-        "title": "Operator Validators",
-        "description": "Number of active validators per operator. Validators are L1 nodes that stake native token and participate in consensus.",
-        "type": "timeseries",
-        "gridPos": { "h": 6, "w": 12, "x": 0, "y": 22 },
-        "targets": [{ "expr": "suzaku_operator_validator_count", "legendFormat": "{{operator}}" }]
-      },
-      {
-        "id": 12,
-        "title": "Operator Delegators",
-        "description": "Number of active delegators per operator. Delegators add stake to existing validators without running a node.",
-        "type": "timeseries",
-        "gridPos": { "h": 6, "w": 12, "x": 12, "y": 22 },
-        "targets": [{ "expr": "suzaku_operator_delegator_count", "legendFormat": "{{operator}}" }]
-      },
-      {
-        "id": 13,
-        "title": "Keeper Tick Duration (ms)",
-        "description": "How long the last keeper tick took. Includes epoch processing, withdrawal prep, harvest, and queue cleanup. Spikes indicate RPC slowness or large batch operations.",
-        "type": "timeseries",
-        "gridPos": { "h": 6, "w": 12, "x": 0, "y": 28 },
-        "targets": [{ "expr": "suzaku_keeper_tick_duration_ms", "legendFormat": "Duration" }]
-      },
-      {
-        "id": 14,
-        "title": "Keeper Errors",
-        "description": "Rate of tick failures. A sustained error rate means the keeper is unable to complete its operations — epochs fall behind, withdrawals stall, queue grows.",
-        "type": "timeseries",
-        "gridPos": { "h": 6, "w": 12, "x": 12, "y": 28 },
-        "targets": [{ "expr": "rate(suzaku_keeper_tick_errors_total[5m])", "legendFormat": "Error rate" }]
-      },
-      {
-        "id": 15,
-        "title": "Events",
-        "description": "Rate of on-chain events observed by the keeper. Deposits, withdrawal requests, claims, epoch processing, and harvests. Useful for understanding vault activity patterns.",
-        "type": "timeseries",
-        "gridPos": { "h": 6, "w": 24, "x": 0, "y": 34 },
-        "targets": [
-          { "expr": "rate(suzaku_events_deposited_total[5m])", "legendFormat": "Deposits" },
-          { "expr": "rate(suzaku_events_withdrawal_requested_total[5m])", "legendFormat": "Withdrawal requests" },
-          { "expr": "rate(suzaku_events_withdrawal_claimed_total[5m])", "legendFormat": "Claims" },
-          { "expr": "rate(suzaku_events_epoch_processed_total[5m])", "legendFormat": "Epochs" },
-          { "expr": "rate(suzaku_events_harvested_total[5m])", "legendFormat": "Harvests" }
-        ]
-      }
-    ],
-    "time": { "from": "now-1h", "to": "now" },
-    "refresh": "15s"
-  },
-  "overwrite": true
+  "title": "Suzaku Keeper",
+  "uid": "suzaku-keeper",
+  "panels": [
+    {
+      "id": 1,
+      "title": "TVL",
+      "description": "Total value locked — getTotalPooledStake(). Sum of all staked assets including those delegated to validators.",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "targets": [{ "expr": "suzaku_tvl", "legendFormat": "TVL" }],
+      "fieldConfig": { "defaults": { "unit": "none", "decimals": 2 } }
+    },
+    {
+      "id": 2,
+      "title": "Solvency Ratio",
+      "description": "getTotalPooledStake() / totalSupply(). Should be ~1.0. Above 1 = undistributed rewards. Below 1 = undercollateralized. At 0, deposits are blocked (insolvency gate).",
+      "type": "gauge",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "targets": [{ "expr": "suzaku_solvency_ratio" }],
+      "fieldConfig": { "defaults": { "min": 0.95, "max": 1.05, "thresholds": { "steps": [{ "value": 0, "color": "red" }, { "value": 0.99, "color": "yellow" }, { "value": 1.0, "color": "green" }] } } }
+    },
+    {
+      "id": 3,
+      "title": "Exchange Rate",
+      "description": "Share-to-asset conversion rate. Starts at 1.0 and grows as rewards accrue. A sudden drop indicates a loss event.",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "targets": [{ "expr": "suzaku_exchange_rate" }],
+      "fieldConfig": { "defaults": { "decimals": 6 } }
+    },
+    {
+      "id": 4,
+      "title": "Vault Status",
+      "description": "0 = Active, 1 = Paused. When paused, deposits and withdrawal requests are blocked. Emergency state set by the vault admin.",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "targets": [{ "expr": "suzaku_vault_paused" }],
+      "fieldConfig": { "defaults": { "mappings": [{ "type": "value", "options": { "0": { "text": "Active", "color": "green" }, "1": { "text": "PAUSED", "color": "red" } } }] } }
+    },
+    {
+      "id": 5,
+      "title": "Epoch Lag",
+      "description": "How many epochs behind the vault is (currentEpoch - lastEpochProcessed). The keeper calls processEpoch() to advance this. Each call processes up to 350 withdrawal entries, so large backlogs take multiple iterations. While epochs are behind, new withdrawal requests cannot be fulfilled.",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 4 },
+      "targets": [{ "expr": "suzaku_epoch_lag", "legendFormat": "Epochs behind" }]
+    },
+    {
+      "id": 6,
+      "title": "Queue Depth",
+      "description": "Number of withdrawal requests waiting in the FIFO queue. The queue is head-of-line blocking — one large unfulfillable request blocks everything behind it. The keeper cleans up claimable entries at the head.",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 4 },
+      "targets": [{ "expr": "suzaku_queue_depth", "legendFormat": "Queue depth" }]
+    },
+    {
+      "id": 7,
+      "title": "Liquidity",
+      "description": "Available Stake = liquid native token in the vault buffer, immediately available for withdrawals without unstaking. Pending Withdrawals = total native token requested but not yet claimable. When available stake drops low, prepareWithdrawals must initiate validator/delegator removals, adding 14+ day delays.",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 10 },
+      "targets": [
+        { "expr": "suzaku_available_stake", "legendFormat": "Available stake" },
+        { "expr": "suzaku_pending_withdrawals", "legendFormat": "Pending withdrawals" }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Pending Protocol Fees",
+      "description": "Unclaimed protocol fees in native token. Requires VAULT_ADMIN_ROLE to claim — the keeper just tracks them.",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 10 },
+      "targets": [{ "expr": "suzaku_pending_protocol_fees", "legendFormat": "Protocol fees" }]
+    },
+    {
+      "id": 9,
+      "title": "Operator Active Stake",
+      "description": "native token actively staked through each operator's validators and delegators.",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 16 },
+      "targets": [{ "expr": "suzaku_operator_active_stake", "legendFormat": "{{operator}}" }]
+    },
+    {
+      "id": 10,
+      "title": "Operator Exit Debt",
+      "description": "native token owed by each operator due to slashing or early exits. At 50% of the operator's allocation, the operator is frozen on-chain.",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 16 },
+      "targets": [{ "expr": "suzaku_operator_exit_debt", "legendFormat": "{{operator}}" }]
+    },
+    {
+      "id": 11,
+      "title": "Operator Validators",
+      "description": "Number of active validators per operator. Validators are L1 nodes that stake native token and participate in consensus.",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 22 },
+      "targets": [{ "expr": "suzaku_operator_validator_count", "legendFormat": "{{operator}}" }]
+    },
+    {
+      "id": 12,
+      "title": "Operator Delegators",
+      "description": "Number of active delegators per operator. Delegators add stake to existing validators without running a node.",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 22 },
+      "targets": [{ "expr": "suzaku_operator_delegator_count", "legendFormat": "{{operator}}" }]
+    },
+    {
+      "id": 13,
+      "title": "Keeper Tick Duration (ms)",
+      "description": "How long the last keeper tick took. Includes epoch processing, withdrawal prep, harvest, and queue cleanup. Spikes indicate RPC slowness or large batch operations.",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 28 },
+      "targets": [{ "expr": "suzaku_keeper_tick_duration_ms", "legendFormat": "Duration" }]
+    },
+    {
+      "id": 14,
+      "title": "Keeper Errors",
+      "description": "Rate of tick failures. A sustained error rate means the keeper is unable to complete its operations — epochs fall behind, withdrawals stall, queue grows.",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 28 },
+      "targets": [{ "expr": "rate(suzaku_keeper_tick_errors_total[5m])", "legendFormat": "Error rate" }]
+    },
+    {
+      "id": 15,
+      "title": "Events",
+      "description": "Rate of on-chain events observed by the keeper. Deposits, withdrawal requests, claims, epoch processing, and harvests. Useful for understanding vault activity patterns.",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 34 },
+      "targets": [
+        { "expr": "rate(suzaku_events_deposited_total[5m])", "legendFormat": "Deposits" },
+        { "expr": "rate(suzaku_events_withdrawal_requested_total[5m])", "legendFormat": "Withdrawal requests" },
+        { "expr": "rate(suzaku_events_withdrawal_claimed_total[5m])", "legendFormat": "Claims" },
+        { "expr": "rate(suzaku_events_epoch_processed_total[5m])", "legendFormat": "Epochs" },
+        { "expr": "rate(suzaku_events_harvested_total[5m])", "legendFormat": "Harvests" }
+      ]
+    }
+  ],
+  "time": { "from": "now-1h", "to": "now" },
+  "refresh": "15s"
 }

--- a/packages/keeper/src/index.ts
+++ b/packages/keeper/src/index.ts
@@ -74,9 +74,17 @@ program
     .addOption(new Option('--pchain-tx-private-key <pchainTxPrivateKey>', 'P-Chain private key for completing registrations/removals').env('PCHAIN_TX_PRIVATE_KEY').argParser(ParserPrivateKey))
     .addOption(new Option('--core', 'Run core operations only').conflicts('completions'))
     .addOption(new Option('--completions', 'Run P-Chain completions only').conflicts('core'))
-    .addOption(new Option('--uptime-blockchain-id <uptimeBlockchainID>', 'Blockchain ID for uptime proofs (auto-read from storage if omitted)').env('UPTIME_BLOCKCHAIN_ID').argParser((v: string) => ParserHex(v)))
+    .addOption(new Option('--uptime-rpc-url <uptimeRpcUrl>', 'RPC URL of the uptime-tracking chain (required when completions are enabled)').env('UPTIME_RPC_URL'))
+    .addOption(new Option('--uptime-blockchain-id <uptimeBlockchainID>', 'Blockchain ID for uptime proofs (auto-read from storage if omitted)').env('UPTIME_BLOCKCHAIN_ID').argParser((v: string) => v ? ParserHex(v) : undefined))
     .action(async (stakingVaultAddress, options) => {
         const opts = program.opts();
+
+        const completionsActive = !!(options.completions || options.pchainTxPrivateKey);
+        if (completionsActive && !options.uptimeRpcUrl) {
+            console.error('Error: --uptime-rpc-url (or UPTIME_RPC_URL) is required when completions are enabled');
+            process.exit(1);
+        }
+
         const client = await generateClient(opts.network as any, opts.privateKey as Hex);
         const config = getConfig(client, opts.wait, opts.skipAbiValidation);
         const stakingVault = await config.contracts.StakingVault(stakingVaultAddress);
@@ -93,7 +101,7 @@ program
                 harvest: options.harvest,
                 coreOnly: options.core,
                 completionsOnly: options.completions,
-                rpcUrl: opts.rpcUrl,
+                rpcUrl: options.uptimeRpcUrl,
                 uptimeBlockchainID: options.uptimeBlockchainId as Hex | undefined,
             });
         } finally {
@@ -111,9 +119,17 @@ program
     .addOption(new Option('--pchain-tx-private-key <pchainTxPrivateKey>', 'P-Chain private key for completing registrations/removals').env('PCHAIN_TX_PRIVATE_KEY').argParser(ParserPrivateKey))
     .addOption(new Option('--core', 'Run core operations only').conflicts('completions'))
     .addOption(new Option('--completions', 'Run P-Chain completions only').conflicts('core'))
-    .addOption(new Option('--uptime-blockchain-id <uptimeBlockchainID>', 'Blockchain ID for uptime proofs (auto-read from storage if omitted)').env('UPTIME_BLOCKCHAIN_ID').argParser((v: string) => ParserHex(v)))
+    .addOption(new Option('--uptime-rpc-url <uptimeRpcUrl>', 'RPC URL of the uptime-tracking chain (required when completions are enabled)').env('UPTIME_RPC_URL'))
+    .addOption(new Option('--uptime-blockchain-id <uptimeBlockchainID>', 'Blockchain ID for uptime proofs (auto-read from storage if omitted)').env('UPTIME_BLOCKCHAIN_ID').argParser((v: string) => v ? ParserHex(v) : undefined))
     .action(async (stakingVaultAddress, options) => {
         const opts = program.opts();
+
+        const completionsActive = !!(options.completions || options.pchainTxPrivateKey);
+        if (completionsActive && !options.uptimeRpcUrl) {
+            console.error('Error: --uptime-rpc-url (or UPTIME_RPC_URL) is required when completions are enabled');
+            process.exit(1);
+        }
+
         const client = await generateClient(opts.network as any, opts.privateKey as Hex);
         const config = getConfig(client, opts.wait, opts.skipAbiValidation);
         const stakingVault = await config.contracts.StakingVault(stakingVaultAddress);
@@ -137,7 +153,7 @@ program
             harvestInterval: options.harvestInterval,
             coreOnly: options.core,
             completionsOnly: options.completions,
-            rpcUrl: opts.rpcUrl,
+            rpcUrl: options.uptimeRpcUrl,
             uptimeBlockchainID: options.uptimeBlockchainId as Hex | undefined,
             monitor,
             onCleanup: cleanup,

--- a/packages/keeper/src/keeper.ts
+++ b/packages/keeper/src/keeper.ts
@@ -14,7 +14,6 @@ import {
     claimWithdrawalsForStakingVault,
     completeValidatorRemovalStakingVault,
     completeDelegatorRemovalStakingVault,
-    completeValidatorRegistrationStakingVault,
     completeDelegatorRegistrationStakingVault,
     getValidatorManagerAddress,
 } from 'suzaku-cli/dist/stakingVault';
@@ -305,6 +304,37 @@ async function completePendingRemovals(
     const operatorList = await stakingVault.read.getOperatorList();
 
     for (const operator of operatorList) {
+
+        // Check delegators pending removal
+        const delegatorIDs = await stakingVault.read.getOperatorDelegators([operator]);
+        for (const delegationID of delegatorIDs) {
+            try {
+                // Check delegator info — if the removal was initiated, the delegator
+                // will still be listed but we need to find the removal event
+                const removalTxHash = await findRemovalTxHash(
+                    client,
+                    stakingVault.address,
+                    'StakingVault__DelegatorRemovalInitiated',
+                    delegationID,
+                    43200n // ~1 day lookback for delegators (vs 7 days for validators)
+                );
+
+                if (!removalTxHash) continue; // Not pending removal
+
+                logger.log(`\nFound pending delegator removal: ${delegationID} (operator: ${operator})`);
+                logger.log(`Found initiate removal tx: ${removalTxHash}`);
+
+                await completeDelegatorRemovalStakingVault(
+                    pchainClient, config, stakingVault, validatorManager,
+                    removalTxHash
+                );
+                delegators++;
+                logger.log(color.green(`Completed delegator removal: ${delegationID}`));
+            } catch (error: any) {
+                logger.warn(`Failed to complete delegator removal ${delegationID}: ${error.message || error}`);
+            }
+        }
+
         // Check validators pending removal
         const validatorIDs = await stakingVault.read.getOperatorValidators([operator]);
         for (const validationID of validatorIDs) {
@@ -336,36 +366,6 @@ async function completePendingRemovals(
                 logger.log(color.green(`Completed validator removal: ${validationID}`));
             } catch (error: any) {
                 logger.warn(`Failed to complete validator removal ${validationID}: ${error.message || error}`);
-            }
-        }
-
-        // Check delegators pending removal
-        const delegatorIDs = await stakingVault.read.getOperatorDelegators([operator]);
-        for (const delegationID of delegatorIDs) {
-            try {
-                // Check delegator info — if the removal was initiated, the delegator
-                // will still be listed but we need to find the removal event
-                const removalTxHash = await findRemovalTxHash(
-                    client,
-                    stakingVault.address,
-                    'StakingVault__DelegatorRemovalInitiated',
-                    delegationID,
-                    43200n // ~1 day lookback for delegators (vs 7 days for validators)
-                );
-
-                if (!removalTxHash) continue; // Not pending removal
-
-                logger.log(`\nFound pending delegator removal: ${delegationID} (operator: ${operator})`);
-                logger.log(`Found initiate removal tx: ${removalTxHash}`);
-
-                await completeDelegatorRemovalStakingVault(
-                    pchainClient, config, stakingVault, validatorManager,
-                    removalTxHash
-                );
-                delegators++;
-                logger.log(color.green(`Completed delegator removal: ${delegationID}`));
-            } catch (error: any) {
-                logger.warn(`Failed to complete delegator removal ${delegationID}: ${error.message || error}`);
             }
         }
     }
@@ -467,13 +467,12 @@ async function completePendingRegistrations(
     rpcUrl?: string,
     uptimeBlockchainID?: Hex,
 ): Promise<{ validators: number; delegators: number }> {
-    let validators = 0;
     let delegators = 0;
 
     const { validatorManagerAddress, stakingManager, stakingManagerStorageLocation } =
         await getValidatorManagerAddress(config, stakingVault);
     const validatorManager = await config.contracts.ValidatorManager(validatorManagerAddress);
-
+    console.log(rpcUrl)
     const resolvedRpcUrl = rpcUrl || client.chain?.rpcUrls?.default?.http?.[0];
     let resolvedUptimeBlockchainID = uptimeBlockchainID;
     if (!resolvedUptimeBlockchainID) {
@@ -490,43 +489,6 @@ async function completePendingRegistrations(
     const operatorList = await stakingVault.read.getOperatorList();
 
     for (const operator of operatorList) {
-        // Check validators pending registration
-        const validatorIDs = await stakingVault.read.getOperatorValidators([operator]);
-        for (const validationID of validatorIDs) {
-            try {
-                const validatorInfo = await validatorManager.read.getValidator([validationID]);
-                // Status 1 = PendingAdded
-                if (validatorInfo.status !== 1) continue;
-
-                logger.log(`\nFound pending validator registration: ${validationID} (operator: ${operator})`);
-
-                const txHash = await findRegistrationTxHash(
-                    client,
-                    stakingVault.address,
-                    'validator',
-                    validationID
-                );
-
-                if (!txHash) {
-                    logger.warn(`Could not find initiate registration tx for validator ${validationID} — skipping`);
-                    continue;
-                }
-
-                logger.log(`Found initiate registration tx: ${txHash}`);
-                // blsProofOfPossession='', initialBalance=0: not needed for keeper completion
-                // — the node is already registered on P-Chain; the keeper only submits the
-                // C-Chain warp completion step.
-                await completeValidatorRegistrationStakingVault(
-                    pchainClient, config, stakingVault, validatorManager,
-                    '', txHash, 0n, false
-                );
-                validators++;
-                logger.log(color.green(`Completed validator registration: ${validationID}`));
-            } catch (error: any) {
-                logger.warn(`Failed to complete validator registration ${validationID}: ${error.message || error}`);
-            }
-        }
-
         // Check delegators pending registration
         const delegatorIDs = await stakingVault.read.getOperatorDelegators([operator]);
         for (const delegationID of delegatorIDs) {
@@ -572,13 +534,13 @@ async function completePendingRegistrations(
         }
     }
 
-    if (validators > 0 || delegators > 0) {
-        logger.log(`\nCompleted ${validators} validator registration(s) and ${delegators} delegator registration(s)`);
+    if (delegators > 0) {
+        logger.log(`\nCompleted ${delegators} delegator registration(s)`);
     } else {
-        logger.log("\nNo pending registrations to complete");
+        logger.log("\nNo pending delegator registrations to complete");
     }
 
-    return { validators, delegators };
+    return { validators: 0, delegators };
 }
 
 // ── Registration event scanning ──────────────────────────────────────
@@ -586,7 +548,7 @@ async function completePendingRegistrations(
 async function findRegistrationTxHash(
     client: ExtendedWalletClient,
     contractAddress: Hex,
-    type: 'validator' | 'delegator',
+    _type: 'delegator',
     id: Hex,
     validationID?: Hex,
 ): Promise<Hex | null> {
@@ -595,40 +557,24 @@ async function findRegistrationTxHash(
     const fromBlock = currentBlock > 302400n ? currentBlock - 302400n : 0n;
 
     try {
-        if (type === 'validator') {
-            const event = parseAbiItem(
-                'event StakingVault__ValidatorRegistrationInitiated(address indexed operator, bytes32 indexed validationID)'
-            );
-            const logs = await client.getLogs({
-                address: contractAddress,
-                event,
-                args: { validationID: id },
-                fromBlock,
-                toBlock: 'latest',
-            });
-            if (logs.length > 0) {
-                return logs[logs.length - 1].transactionHash;
-            }
-        } else {
-            // delegationID is NOT indexed — filter by validationID (indexed), then match delegationID in data
-            const event = parseAbiItem(
-                'event StakingVault__DelegatorRegistrationInitiated(address indexed operator, bytes32 indexed validationID, bytes32 delegationID, uint256 amount)'
-            );
-            const logs = await client.getLogs({
-                address: contractAddress,
-                event,
-                args: { validationID },
-                fromBlock,
-                toBlock: 'latest',
-            });
-            for (let i = logs.length - 1; i >= 0; i--) {
-                if (logs[i].args.delegationID === id) {
-                    return logs[i].transactionHash;
-                }
+        // delegationID is NOT indexed — filter by validationID (indexed), then match delegationID in data
+        const event = parseAbiItem(
+            'event StakingVault__DelegatorRegistrationInitiated(address indexed operator, bytes32 indexed validationID, bytes32 delegationID, uint256 amount)'
+        );
+        const logs = await client.getLogs({
+            address: contractAddress,
+            event,
+            args: { validationID },
+            fromBlock,
+            toBlock: 'latest',
+        });
+        for (let i = logs.length - 1; i >= 0; i--) {
+            if (logs[i].args.delegationID === id) {
+                return logs[i].transactionHash;
             }
         }
     } catch (error: any) {
-        logger.debug(`Event scan failed for ${type} registration: ${error.message || error}`);
+        logger.debug(`Event scan failed for delegator registration: ${error.message || error}`);
     }
 
     return null;
@@ -701,7 +647,7 @@ export async function keeperWatch(
             try {
                 logger.log(color.bold(`\n── Keeper tick at ${new Date().toISOString()} ──`));
 
-                await monitor?.collectVaultMetrics(stakingVault).catch(() => {});
+                await monitor?.collectVaultMetrics(stakingVault).catch(() => { });
 
                 const tickBody = keeperRun(client, pchainClient, config, stakingVault, {
                     harvest: shouldHarvest,

--- a/packages/keeper/src/keeper.ts
+++ b/packages/keeper/src/keeper.ts
@@ -305,36 +305,6 @@ async function completePendingRemovals(
 
     for (const operator of operatorList) {
 
-        // Check delegators pending removal
-        const delegatorIDs = await stakingVault.read.getOperatorDelegators([operator]);
-        for (const delegationID of delegatorIDs) {
-            try {
-                // Check delegator info — if the removal was initiated, the delegator
-                // will still be listed but we need to find the removal event
-                const removalTxHash = await findRemovalTxHash(
-                    client,
-                    stakingVault.address,
-                    'StakingVault__DelegatorRemovalInitiated',
-                    delegationID,
-                    43200n // ~1 day lookback for delegators (vs 7 days for validators)
-                );
-
-                if (!removalTxHash) continue; // Not pending removal
-
-                logger.log(`\nFound pending delegator removal: ${delegationID} (operator: ${operator})`);
-                logger.log(`Found initiate removal tx: ${removalTxHash}`);
-
-                await completeDelegatorRemovalStakingVault(
-                    pchainClient, config, stakingVault, validatorManager,
-                    removalTxHash
-                );
-                delegators++;
-                logger.log(color.green(`Completed delegator removal: ${delegationID}`));
-            } catch (error: any) {
-                logger.warn(`Failed to complete delegator removal ${delegationID}: ${error.message || error}`);
-            }
-        }
-
         // Check validators pending removal
         const validatorIDs = await stakingVault.read.getOperatorValidators([operator]);
         for (const validationID of validatorIDs) {
@@ -366,6 +336,36 @@ async function completePendingRemovals(
                 logger.log(color.green(`Completed validator removal: ${validationID}`));
             } catch (error: any) {
                 logger.warn(`Failed to complete validator removal ${validationID}: ${error.message || error}`);
+            }
+        }
+
+        // Check delegators pending removal
+        const delegatorIDs = await stakingVault.read.getOperatorDelegators([operator]);
+        for (const delegationID of delegatorIDs) {
+            try {
+                // Check delegator info — if the removal was initiated, the delegator
+                // will still be listed but we need to find the removal event
+                const removalTxHash = await findRemovalTxHash(
+                    client,
+                    stakingVault.address,
+                    'StakingVault__DelegatorRemovalInitiated',
+                    delegationID,
+                    43200n // ~1 day lookback for delegators (vs 7 days for validators)
+                );
+
+                if (!removalTxHash) continue; // Not pending removal
+
+                logger.log(`\nFound pending delegator removal: ${delegationID} (operator: ${operator})`);
+                logger.log(`Found initiate removal tx: ${removalTxHash}`);
+
+                await completeDelegatorRemovalStakingVault(
+                    pchainClient, config, stakingVault, validatorManager,
+                    removalTxHash
+                );
+                delegators++;
+                logger.log(color.green(`Completed delegator removal: ${delegationID}`));
+            } catch (error: any) {
+                logger.warn(`Failed to complete delegator removal ${delegationID}: ${error.message || error}`);
             }
         }
     }

--- a/packages/keeper/src/keeper.ts
+++ b/packages/keeper/src/keeper.ts
@@ -472,7 +472,6 @@ async function completePendingRegistrations(
     const { validatorManagerAddress, stakingManager, stakingManagerStorageLocation } =
         await getValidatorManagerAddress(config, stakingVault);
     const validatorManager = await config.contracts.ValidatorManager(validatorManagerAddress);
-    console.log(rpcUrl)
     const resolvedRpcUrl = rpcUrl || client.chain?.rpcUrls?.default?.http?.[0];
     let resolvedUptimeBlockchainID = uptimeBlockchainID;
     if (!resolvedUptimeBlockchainID) {
@@ -511,7 +510,6 @@ async function completePendingRegistrations(
                 const txHash = await findRegistrationTxHash(
                     client,
                     stakingVault.address,
-                    'delegator',
                     delegationID,
                     delegatorInfo.validationID
                 );
@@ -548,7 +546,6 @@ async function completePendingRegistrations(
 async function findRegistrationTxHash(
     client: ExtendedWalletClient,
     contractAddress: Hex,
-    _type: 'delegator',
     id: Hex,
     validationID?: Hex,
 ): Promise<Hex | null> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2354,7 +2354,7 @@ async function main() {
         .addOption(optKiteStakingManagerAddress)
         .addArgument(ArgHex("delegationID", "Delegation ID"))
         .addOption(new Option("--include-uptime-proof", "Include uptime proof in the removal").default(false))
-        .addOption(new Option("--rpc-url <rpcUrl>", "RPC URL for getting validator uptime (required if --include-uptime-proof is true)"))
+        .addOption(new Option("--rpc-url <rpcUrl>", "RPC URL for getting validator uptime (required if --include-uptime-proof is true) eg. https://<ip>:<port>/ext/bc/<chainID>"))
         .asyncAction({ signer: true }, async (config, delegationID, options) => {
             const kiteStakingManager = await config.contracts.KiteStakingManager(options.stakingManagerAddress);
             await initiateDelegatorRemoval(
@@ -2371,7 +2371,7 @@ async function main() {
         .description("Complete delegator removal on the P-Chain and on the KiteStakingManager after initiating removal")
         .addOption(optKiteStakingManagerAddress)
         .addArgument(ArgHex("initiateRemovalTxHash", "Initiate delegator removal transaction hash"))
-        .argument("rpcUrl", "RPC URL for getting validator uptime")
+        .argument("rpcUrl <string>", "RPC URL for getting validator uptime eg. https://<ip>:<port>/ext/bc/<chainID>")
         .addOption(new Option("--pchain-tx-private-key <pchainTxPrivateKey>", "P-Chain transaction private key/secret name or 'ledger'. Defaults to the private key.").argParser(ParserPrivateKey))
         .addOption(new Option("--skip-wait-api", "Don't wait for the validator to be visible through the P-Chain API"))
         .addOption(new Option("--delegation-id <delegationID>", "Delegation ID of the delegator being removed").default([] as Hex[]).argParser(collectMultiple(ParserHex)))
@@ -2443,7 +2443,7 @@ async function main() {
         .description("Submit uptime proof for a validator")
         .addOption(optKiteStakingManagerAddress)
         .addArgument(ArgNodeID("nodeId", "Node ID of the validator"))
-        .argument("rpcUrl", "RPC URL for getting validator uptime")
+        .argument("rpcUrl", "RPC URL for getting validator uptime eg. https://<ip>:<port>/ext/bc/<chainID>")
         .asyncAction({ signer: true }, async (config, nodeId, rpcUrl, options) => {
             const kiteStakingManager = await config.contracts.KiteStakingManager(options.stakingManagerAddress);
             await submitUptimeProof(
@@ -2761,7 +2761,7 @@ async function main() {
         .description("Complete delegator registration on the P-Chain and on the StakingVault after initiating registration")
         .addOption(optStakingVaultAddress)
         .addArgument(ArgHex("initiateTxHash", "Initiate delegator registration transaction hash"))
-        .argument("rpcUrl", "RPC URL for getting validator uptime (e.g. http(s)://domainOrIp:portIfNeeded)")
+        .argument("rpcUrl", "RPC URL for getting validator uptime (eg. https://<ip>:<port>/ext/bc/<chainID>)")
         .addOption(new Option("--pchain-tx-private-key <pchainTxPrivateKey>", "P-Chain transaction private key/secret name or 'ledger'. Defaults to the private key.").argParser(ParserPrivateKey))
         .asyncAction({ signer: true }, async (config, initiateTxHash, rpcUrl, options) => {
             const opts = program.opts();
@@ -3321,7 +3321,7 @@ async function main() {
     uptimeCmd
         .command("get-validation-uptime-message")
         .description("Get the validation uptime message for a given validator in the given L1 RPC")
-        .addArgument(ArgURI("rpcUrl", "RPC URL like 'http(s)://<domain or ip and port>'"))
+        .addArgument(ArgURI("rpcUrl", "RPC URL eg. https://<ip>:<port>/ext/bc/<chainID>"))
         .addArgument(ArgCB58("blockchainId", "Blockchain ID"))
         .addArgument(ArgNodeID())
         .asyncAction(async (config, rpcUrl, blockchainId, nodeId) => {
@@ -3351,7 +3351,7 @@ async function main() {
     uptimeCmd
         .command("report-uptime-validator")
         .description("Gets a validator's signed uptime message and submits it to the UptimeTracker contract.")
-        .addArgument(ArgURI("rpcUrl", "RPC URL like 'http(s)://<domain or ip and port>'"))
+        .addArgument(ArgURI("rpcUrl", "RPC URL eg. https://<ip>:<port>/ext/bc/<chainID>"))
         .addArgument(ArgCB58("blockchainId", "The Blockchain ID for which the uptime is being reported"))
         .addArgument(ArgNodeID("nodeId", "The NodeID of the validator"))
         .addArgument(argUptimeTrackerAddress)
@@ -3361,9 +3361,6 @@ async function main() {
                 logger.error("Error: Private key is required. Use -k or set PK environment variable.");
                 process.exit(1);
             }
-
-
-            rpcUrl = rpcUrl + "/ext/bc/" + blockchainId;
 
             await reportAndSubmitValidatorUptime(
                 config.client,
@@ -3489,7 +3486,7 @@ async function main() {
         .description("Report uptime for all validators")
         .addArgument(argUptimeTrackerAddress)
         .addArgument(argMiddlewareAddress)
-        .argument("rpcUrl", "RPC URL of the network")
+        .argument("rpcUrl", "RPC URL eg. https://<ip>:<port>/ext/bc/<chainID>")
         .addArgument(ArgCB58("blockchainId", "The Blockchain ID for which the uptime is being reported"))
         .addOption(new Option("--epoch <epoch>", "Epoch number to check (defaults to current epoch)").argParser(ParserNumber))
         .asyncAction({ signer: true }, async (config, uptimeTrackerAddress, middlewareAddress, rpcUrl, blockchainId, options) => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -101,7 +101,6 @@ import {
     isOperatorUptimeSetForEpoch,
     getLastUptimeCheckpoint,
     uptimeSync,
-    uptimeSyncLight
 } from "./uptime";
 
 import {
@@ -3498,26 +3497,6 @@ async function main() {
             const middlewareSvc = await config.contracts.L1Middleware(middlewareAddress);
 
             await uptimeSync(
-                config.client,
-                uptimeTracker,
-                middlewareSvc,
-                rpcUrl,
-                blockchainId
-            );
-        });
-
-    uptimeCmd
-        .command("uptime-sync-light")
-        .description("Report validator uptime only (no operator epoch backfill), for keeper daemon use")
-        .addArgument(argUptimeTrackerAddress)
-        .addArgument(argMiddlewareAddress)
-        .argument("rpcUrl", "RPC URL of the network")
-        .addArgument(ArgCB58("blockchainId", "The Blockchain ID for which the uptime is being reported"))
-        .asyncAction({ signer: true }, async (config, uptimeTrackerAddress, middlewareAddress, rpcUrl, blockchainId) => {
-            const uptimeTracker = await config.contracts.UptimeTracker(uptimeTrackerAddress);
-            const middlewareSvc = await config.contracts.L1Middleware(middlewareAddress);
-
-            await uptimeSyncLight(
                 config.client,
                 uptimeTracker,
                 middlewareSvc,

--- a/src/client.ts
+++ b/src/client.ts
@@ -77,7 +77,7 @@ export async function generateClient(chain: Chains, privateKey?: Hex | 'ledger',
             ...createPublicClient({
                 chain: chainList[chain],
                 transport: http(),
-                
+
             }).extend(publicActions),
             network,
             safe: safe ? await createSafeClient({

--- a/src/lib/nodeUtils.ts
+++ b/src/lib/nodeUtils.ts
@@ -1,0 +1,6 @@
+import { InfoApi } from "@avalabs/avalanchejs/dist/info";
+
+export async function getNodeID(rpcUrl: string) {
+    const infoAPI = new InfoApi(rpcUrl);
+    return await infoAPI.getNodeId();
+}

--- a/src/lib/viemUtils.ts
+++ b/src/lib/viemUtils.ts
@@ -93,7 +93,7 @@ type MulticallFn<T extends SuzakuABINames> = {
 };
 
 // Define a curried function to create a contract instance progressively (generic to keep type inference)
-export type CurriedContractFn<T extends SuzakuABINames, C extends ExtendedClient> = (address?: Address) => Promise<C extends ExtendedWalletClient ? SafeSuzakuContract[T] : SuzakuContract[T]>;
+export type CurriedContractFn<T extends SuzakuABINames, C extends ExtendedClient> = (address?: Address, _skipAbiValidation?: boolean) => Promise<C extends ExtendedWalletClient ? SafeSuzakuContract[T] : SuzakuContract[T]>;
 export type CurriedSuzakuContractMap<C extends ExtendedClient> = { [key in SuzakuABINames]: CurriedContractFn<key, C> }
 
 function handleContractError(error: any, abi: SuzakuABINames) {
@@ -325,14 +325,14 @@ return contract as unknown as SuzakuContract[T];
 }
 
 export const curriedContract = <T extends SuzakuABINames, C extends ExtendedClient>(abi: T, client: C, wait = 0, skipAbiValidation: boolean = false): CurriedContractFn<T, C> =>
-  async (address?: Address) => {
+  async (address?: Address, _skipAbiValidation: boolean = skipAbiValidation) => {
     // format camelCase ABI name to SCREAMING_SNAKE_CASE for env var lookup
     const envVar = abi.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toUpperCase()
     if (!address) {
       if (process.env[envVar]) address = process.env[envVar] as Address;
       else throw new Error(`Address is required to create a contract instance for ${abi}. Please provide associated option or set as environment variable ${envVar}`);
     }
-    if (!skipAbiValidation) {
+    if (!_skipAbiValidation) {
       // (StakingVault uses delegatecall to forward to operations implementation)
       // Skip ABI validation since functions are forwarded via fallback
       if (abi.includes("StakingVault")) {

--- a/src/stakingVault.ts
+++ b/src/stakingVault.ts
@@ -986,7 +986,7 @@ export async function completeDelegatorRegistrationStakingVault(
     logger.log("\nGetting validation uptime message...");
     const signedUptimeMessage = await getValidationUptimeMessage(
         client,
-        `${rpcUrl}/ext/bc/${sourceChainID}`,
+        `${rpcUrl}`,
         nodeId,
         warpNetworkID,
         sourceChainID

--- a/src/stakingVault.ts
+++ b/src/stakingVault.ts
@@ -1,14 +1,13 @@
-import { ExtendedClient, ExtendedPublicClient, ExtendedWalletClient } from './client';
+import { ExtendedClient, ExtendedWalletClient } from './client';
 import { Config } from './config';
-import { CurriedSuzakuContractMap, SafeSuzakuContract, SuzakuContract, withSafeWrite } from './lib/viemUtils';
+import { SafeSuzakuContract, SuzakuContract } from './lib/viemUtils';
 import { parseUnits, parseEventLogs, Hex, hexToBytes, bytesToHex, formatUnits } from 'viem';
 import { logger } from './lib/logger';
-import { parseNodeID, NodeId, encodeNodeID, retryWhileError, bytes32ToAddress } from './lib/utils';
-import { getContract } from 'viem';
+import { parseNodeID, NodeId, encodeNodeID, retryWhileError, bytes32ToAddress, bytesToCB58 } from './lib/utils';
 import { color } from 'console-log-colors';
 import { collectSignatures, getSigningSubnetIdFromWarpMessage, packL1ValidatorRegistration, packL1ValidatorWeightMessage, packWarpIntoAccessList } from './lib/warpUtils';
 import { getValidationUptimeMessage } from './uptime';
-import { getCurrentValidators, registerL1Validator, setValidatorWeight, validatedBy } from './lib/pChainUtils';
+import { getCurrentValidators, registerL1Validator, setValidatorWeight } from './lib/pChainUtils';
 import { GetRegistrationJustification } from './lib/justification';
 import { pipe, R } from '@mobily/ts-belt';
 import { utils } from '@avalabs/avalanchejs';
@@ -1166,6 +1165,10 @@ export async function completeDelegatorRemovalStakingVault(
         logs: receipt.logs,
     });
 
+    const subnetIdHex = await validatorManager.read.subnetID()
+    const subnetId = utils.base58check.encode(hexToBytes(subnetIdHex))
+    const currentValidators = await getCurrentValidators(client, subnetId)
+
     let lastHash: Hex | undefined;
 
     for (const event of filteredRemovals) {
@@ -1184,85 +1187,70 @@ export async function completeDelegatorRemovalStakingVault(
         const validator = await validatorManager.read.getValidator([validationID]);
         const nodeID = encodeNodeID(validator.nodeID as Hex);
         logger.log(`Processing removal for delegation ${delegationID}, node ${nodeID}`);
+        const currentValidator = currentValidators.find(v => v.nodeID === nodeID);
+        let accessList;
+        if (currentValidator) {
+            // Look for InitiatedValidatorWeightUpdate events from ValidatorManager (similar to completeWeightUpdate)
+            const initiatedValidatorWeightUpdates = parseEventLogs({
+                abi: validatorManager.abi,
+                logs: receipt.logs,
+                eventName: 'InitiatedValidatorWeightUpdate'
+            }).filter((e) => e.args.validationID === validationID);
 
-        let addNodeBlockNumber = receipt.blockNumber;
-
-        if (initiateTxHash) {
-            const addNodeReceipt = await client.waitForTransactionReceipt({ hash: initiateTxHash, confirmations: 0 });
-            if (addNodeReceipt.status === 'reverted') throw new Error(`Transaction ${initiateTxHash} reverted, pls use another initiate tx`);
-
-            // Check if this delegationID is in the registration event
-            const registrationEvents = parseEventLogs({
-                abi: stakingVault.abi,
-                logs: addNodeReceipt.logs,
-                eventName: 'StakingVault__DelegatorRegistrationInitiated'
-            });
-
-            if (registrationEvents.some((e) => e.args?.delegationID === delegationID)) {
-                addNodeBlockNumber = addNodeReceipt.blockNumber;
+            if (initiatedValidatorWeightUpdates.length === 0) {
+                logger.error(color.red(`No InitiatedValidatorWeightUpdate event found for validationID ${validationID}`));
+                continue;
             }
+
+            const weightUpdateEvent = initiatedValidatorWeightUpdates[0];
+            const warpLog = warpLogs.find((w) => w.args.messageID === weightUpdateEvent.args.weightUpdateMessageID);
+            if (!warpLog) {
+                logger.error(color.red(`No matching warp log found for weightUpdateMessageID ${weightUpdateEvent.args.weightUpdateMessageID}`));
+                continue;
+            }
+
+            const signingSubnetId = await getSigningSubnetIdFromWarpMessage(client, warpLog.args.message);
+
+            const unsignedL1ValidatorWeightMessage = warpLog.args.message;
+            const weight = weightUpdateEvent.args.weight;
+            const nonce = weightUpdateEvent.args.nonce;
+
+            // Aggregate signatures from validators for the weight message
+            logger.log("\nCollecting signatures for the L1ValidatorWeightMessage from the Validator Manager chain...");
+            const signedL1ValidatorWeightMessage = await collectSignatures({ network: client.network, message: unsignedL1ValidatorWeightMessage, signingSubnetId });
+            logger.log("Aggregated signatures for the L1ValidatorWeightMessage from the Validator Manager chain");
+
+            // Call setValidatorWeight on the P-Chain with the signed L1ValidatorWeightMessage
+            logger.log("\nSetting validator weight on P-Chain...");
+            pipe(await setValidatorWeight({
+                client: pchainClient,
+                validationID: validationID,
+                message: signedL1ValidatorWeightMessage
+            }),
+                R.tap(pChainSetWeightTxId => logger.log("SetL1ValidatorWeightTx executed on P-Chain:", pChainSetWeightTxId)),
+                R.tapError(err => {
+                    if (!err.includes('warp message contains stale nonce')) {
+                        logger.error(err);
+                        process.exit(1);
+                    }
+                    logger.warn(color.yellow(`Warning: Skipping SetL1ValidatorWeightTx for validationID ${validationID} due to stale nonce (already issued)`));
+                }));
+            // Pack and sign the P-Chain warp message for weight update
+            const validationIDBytes = hexToBytes(validationID as Hex);
+            const unsignedPChainWarpMsg = packL1ValidatorWeightMessage(validationIDBytes, BigInt(nonce), BigInt(weight), client.network === 'fuji' ? 5 : 1, pChainChainID);
+            const unsignedPChainWarpMsgHex = bytesToHex(unsignedPChainWarpMsg);
+
+            // Aggregate signatures from validators for the P-Chain weight message
+            logger.log("\nAggregating signatures for the L1ValidatorWeightMessage from the P-Chain...");
+            const signedPChainMessage = await collectSignatures({ network: client.network, message: unsignedPChainWarpMsgHex, justification: unsignedPChainWarpMsgHex, signingSubnetId });
+            logger.log("Aggregated signatures for the L1ValidatorWeightMessage from the P-Chain");
+
+            // Convert the signed warp message to bytes and pack into access list
+            const signedPChainWarpMsgBytes = hexToBytes(`0x${signedPChainMessage}`);
+            accessList = packWarpIntoAccessList(signedPChainWarpMsgBytes);
+        } else {
+            logger.log(`No weight update needed for delegation ${delegationID} as its weight is already 0`);
         }
-
-        // Look for InitiatedValidatorWeightUpdate events from ValidatorManager (similar to completeWeightUpdate)
-        const initiatedValidatorWeightUpdates = parseEventLogs({
-            abi: validatorManager.abi,
-            logs: receipt.logs,
-            eventName: 'InitiatedValidatorWeightUpdate'
-        }).filter((e) => e.args.validationID === validationID);
-
-        if (initiatedValidatorWeightUpdates.length === 0) {
-            logger.error(color.red(`No InitiatedValidatorWeightUpdate event found for validationID ${validationID}`));
-            continue;
-        }
-
-        const weightUpdateEvent = initiatedValidatorWeightUpdates[0];
-        const warpLog = warpLogs.find((w) => w.args.messageID === weightUpdateEvent.args.weightUpdateMessageID);
-        if (!warpLog) {
-            logger.error(color.red(`No matching warp log found for weightUpdateMessageID ${weightUpdateEvent.args.weightUpdateMessageID}`));
-            continue;
-        }
-
-        const signingSubnetId = await getSigningSubnetIdFromWarpMessage(client, warpLog.args.message);
-
-        const unsignedL1ValidatorWeightMessage = warpLog.args.message;
-        const weight = weightUpdateEvent.args.weight;
-        const nonce = weightUpdateEvent.args.nonce;
-
-        // Aggregate signatures from validators for the weight message
-        logger.log("\nCollecting signatures for the L1ValidatorWeightMessage from the Validator Manager chain...");
-        const signedL1ValidatorWeightMessage = await collectSignatures({ network: client.network, message: unsignedL1ValidatorWeightMessage, signingSubnetId });
-        logger.log("Aggregated signatures for the L1ValidatorWeightMessage from the Validator Manager chain");
-
-        // Call setValidatorWeight on the P-Chain with the signed L1ValidatorWeightMessage
-        logger.log("\nSetting validator weight on P-Chain...");
-        pipe(await setValidatorWeight({
-            client: pchainClient,
-            validationID: validationID,
-            message: signedL1ValidatorWeightMessage
-        }),
-            R.tap(pChainSetWeightTxId => logger.log("SetL1ValidatorWeightTx executed on P-Chain:", pChainSetWeightTxId)),
-            R.tapError(err => {
-                if (!err.includes('warp message contains stale nonce')) {
-                    logger.error(err);
-                    process.exit(1);
-                }
-                logger.warn(color.yellow(`Warning: Skipping SetL1ValidatorWeightTx for validationID ${validationID} due to stale nonce (already issued)`));
-            }));
-
-        // Pack and sign the P-Chain warp message for weight update
-        const validationIDBytes = hexToBytes(validationID as Hex);
-        const unsignedPChainWarpMsg = packL1ValidatorWeightMessage(validationIDBytes, BigInt(nonce), BigInt(weight), client.network === 'fuji' ? 5 : 1, pChainChainID);
-        const unsignedPChainWarpMsgHex = bytesToHex(unsignedPChainWarpMsg);
-
-        // Aggregate signatures from validators for the P-Chain weight message
-        logger.log("\nAggregating signatures for the L1ValidatorWeightMessage from the P-Chain...");
-        const signedPChainMessage = await collectSignatures({ network: client.network, message: unsignedPChainWarpMsgHex, justification: unsignedPChainWarpMsgHex, signingSubnetId });
-        logger.log("Aggregated signatures for the L1ValidatorWeightMessage from the P-Chain");
-
-        // Convert the signed warp message to bytes and pack into access list
-        const signedPChainWarpMsgBytes = hexToBytes(`0x${signedPChainMessage}`);
-        const accessList = packWarpIntoAccessList(signedPChainWarpMsgBytes);
-
         // messageIndex is always 0 for StakingVaultOperations
         const messageIndex = 0;
 

--- a/src/uptime.ts
+++ b/src/uptime.ts
@@ -272,7 +272,7 @@ export async function uptimeSync(
     return;
   }
 
-  let currentValidators = await getCurrentValidatorsFromNode(rpcUrl + `/ext/bc/${sourceChainID}`);
+  let currentValidators = await getCurrentValidatorsFromNode(rpcUrl);
   if (currentValidators.length === 0) {
     logger.log("No validators found for any operator.");
     return;
@@ -384,7 +384,7 @@ export async function uptimeSyncLight(
     logger.log("No operators found.");
     return;
   }
-  let currentValidators = await getCurrentValidatorsFromNode(rpcUrl + `/ext/bc/${sourceChainID}`);
+  let currentValidators = await getCurrentValidatorsFromNode(rpcUrl);
 
   if (currentValidators.length === 0) {
     logger.log("No validators found for any operator.");


### PR DESCRIPTION
### Changes

- Remove validator registration.
- Fix Grafana dashboard.
- Add a `UPTIME_RPC_URL` requirement to retrieve node uptime.
- Put the delegator removal before validator removal (avoid the `could not load L1 validator: not found` error)
- uptimeSyncLight removed (no associated function)
